### PR TITLE
Feature/improve compiler warnings

### DIFF
--- a/cmake/SkeletonCompilerWarnings.cmake
+++ b/cmake/SkeletonCompilerWarnings.cmake
@@ -14,6 +14,11 @@ if(SKELETON_ENABLE_COMPILER_WARNINGS)
     )
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(Skeleton_CompilerWarnings INTERFACE
+      # Suppress warnings from headers included with <...>.
+      /experimental:external # Needed before MSVC 2019 version 16.10.
+      /external:anglebrackets
+      /external:W0
+      # Apply the following warnings.
       /W4
     )
   endif()


### PR DESCRIPTION
Improve compiler warnings.

* Use if blocks rather than generator expressions to select warning flags depending on the compiler,
* Suppress MSVC warnings from external headers.