### PR TITLE
Add CMake option SKELETON_USE_SANITIZERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(SkeletonCompilerWarnings)
 include(SkeletonDefaultBuildType)
 include(SkeletonForceEnableAsserts)
 include(SkeletonOutputDirectories)
+include(SkeletonUseSanitizers)
 
 option(SKELETON_BUILD_EXAMPLES "Build examples" OFF)
 option(SKELETON_BUILD_DOCUMENTATION "Build documentation" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,12 +24,12 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -O3",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "SKELETON_BUILD_EXAMPLES": "ON",
                 "SKELETON_BUILD_UNIT_TESTS": "ON",
                 "SKELETON_ENABLE_COMPILER_WARNINGS": "ON",
-                "SKELETON_FORCE_ENABLE_ASSERTS": "ON"
+                "SKELETON_FORCE_ENABLE_ASSERTS": "ON",
+                "SKELETON_USE_SANITIZERS": "ON"
             }
         }
     ]

--- a/cmake/SkeletonUseSanitizers.cmake
+++ b/cmake/SkeletonUseSanitizers.cmake
@@ -1,0 +1,29 @@
+option(SKELETON_USE_SANITIZERS "Use address and UB sanitizers (if available)" OFF)
+
+if(NOT SKELETON_USE_SANITIZERS)
+  return()
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang|GNU)$")
+  add_compile_options(
+    -fsanitize=address,undefined
+    -O2
+    -g
+    -fno-omit-frame-pointer
+  )
+  add_link_options(
+    -fsanitize=address,undefined
+  )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  add_compile_options(
+    /fsanitize=address
+    /O2
+    /Zi
+    /Oy-
+  )
+  add_link_options(
+    /fsanitize=address
+    /DEBUG
+  )
+  message(STATUS "The UB sanitizer is not available for MSVC.")
+endif()


### PR DESCRIPTION
A dedicated options to enable the sanitizers is more robust than injecting flags via CMAKE_CXX_FLAGS.