### PR TITLE
Require GCC or Clang for sanitizers

### DIFF
--- a/cmake/SkeletonUseSanitizers.cmake
+++ b/cmake/SkeletonUseSanitizers.cmake
@@ -1,4 +1,4 @@
-option(SKELETON_USE_SANITIZERS "Use address and UB sanitizers (if available)" OFF)
+option(SKELETON_USE_SANITIZERS "Use address and UB sanitizers (requires GCC or Clang)" OFF)
 
 if(NOT SKELETON_USE_SANITIZERS)
   return()
@@ -14,16 +14,4 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang|GNU)$")
   add_link_options(
     -fsanitize=address,undefined
   )
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(
-    /fsanitize=address
-    /O2
-    /Zi
-    /Oy-
-  )
-  add_link_options(
-    /fsanitize=address
-    /DEBUG
-  )
-  message(STATUS "The UB sanitizer is not available for MSVC.")
 endif()


### PR DESCRIPTION
Using the address sanitizer with MSVC requires a bit more thought.