### PR TITLE
Broaden build ignore glob and ignore .gdb_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 __pycache__/
 .cache/
 .vscode/
-build/
+build*/
 install/
 user_test/
+.gdb_history
 CMakeUserPresets.json
 core*


### PR DESCRIPTION
Match build directories with suffixes (e.g. build-rpi, build-debug) by using build*/ instead of build/, and ignore GDB's .gdb_history.