### PR TITLE
Add a pre-commit hook to check CMake formatting

### DIFF
--- a/tools/git_hooks/pre-commit
+++ b/tools/git_hooks/pre-commit
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+FAILED=0
+
+mapfile -t -d '' CMAKE_FILES_TO_CHECK < <(git diff --cached --name-only --diff-filter=d -z | grep -zE '(CMakeLists\.txt|\.cmake|\.cmake\.in)$')
+if [ ${#CMAKE_FILES_TO_CHECK[@]} -gt 0 ]; then
+    python3 "${PROJECT_ROOT}/tools/cmake_formatting.py" --quiet "${CMAKE_FILES_TO_CHECK[@]}" || FAILED=1
+fi
+
+if [ "${FAILED}" -ne 0 ]; then
+    echo ""
+    echo "Commit aborted by pre-commit hook."
+fi
+
+exit ${FAILED}

--- a/tools/install_git_hooks.sh
+++ b/tools/install_git_hooks.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+cd $(dirname $0)
+
+git config core.hooksPath tools/git_hooks


### PR DESCRIPTION
Add tools/git_hooks/pre-commit, which checks the formatting of staged CMake files with tools/cmake_formatting.py, and tools/install_git_hooks.sh, which points core.hooksPath at tools/git_hooks so the hook is used.