### PR TITLE
Preserve trailing newline when generating a project

### DIFF
--- a/tools/generate_project.py
+++ b/tools/generate_project.py
@@ -42,7 +42,13 @@ def remove_skips(src):
   if skip:
     raise ValueError("Reached end of file while looking for SKIP_END")
 
-  return "\n".join(dst_lines)
+  result = "\n".join(dst_lines)
+  # splitlines() drops the final line terminator; restore it so generated
+  # files keep a trailing newline (POSIX text files, formatters, and linters
+  # expect one).
+  if src.endswith("\n"):
+    result += "\n"
+  return result
 
 def transform_text(src, output_name):
   return (


### PR DESCRIPTION
remove_skips joined lines with "\n" after splitlines(), which drops the file's final line terminator, so every generated file lost its trailing newline. Restore it when the source file had one, matching the expectations of POSIX text tools, formatters, and linters.