### PR TITLE
Build and test Linux CI in a prebuilt Docker image

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,10 +4,68 @@ on:
   - push
 
 jobs:
-  dev:
+  build-docker-image:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Log in to the GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push the CI image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/skeleton/ci:latest
+
+  build-and-test-linux:
+    needs: build-docker-image
+
+    runs-on: ubuntu-24.04
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/skeleton/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - uses: actions/checkout@v7
+
+    # Dependencies and CMAKE_PREFIX_PATH are baked into the CI image.
+    - name: Build
+      run: |
+        cmake --preset dev -D CMAKE_BUILD_TYPE=RelWithDebInfo -D SKELETON_BUILD_DOCUMENTATION=OFF -D SKELETON_ENABLE_INSTALL=OFF
+        cmake --build build --config RelWithDebInfo
+
+    - name: Check that install is disabled
+      run: |
+        cmake --install build --config RelWithDebInfo --prefix install
+        python3 -c "import os; assert not os.path.exists('install'), 'install exists even though ENABLE_INSTALL=OFF';"
+
+    - name: Test
+      run: |
+        ctest --test-dir build --build-config RelWithDebInfo --output-on-failure
+
+    - name: User test
+      run: |
+        cmake -P tools/user_test.cmake
+
+  build-and-test-windows-macos:
     strategy:
       matrix:
-        runner: [ubuntu-22.04, windows-2022, macos-14]
+        runner: [windows-2022, macos-14]
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,34 +4,23 @@ on:
   - push
 
 jobs:
-  build-docker-image:
+  cmake-formatting:
     runs-on: ubuntu-24.04
 
-    permissions:
-      contents: read
-      packages: write
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/skeleton/ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/checkout@v7
 
-    - name: Log in to the GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build and push the CI image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: docker/Dockerfile
-        push: true
-        tags: ghcr.io/${{ github.repository_owner }}/skeleton/ci:latest
+    - name: Check formatting
+      run: |
+        ./tools/cmake_formatting.py --diff
 
   build-and-test-linux:
-    needs: build-docker-image
-
     runs-on: ubuntu-24.04
 
     container:
@@ -171,18 +160,4 @@ jobs:
         cmake -P tools/user_test.cmake
       env:
         CMAKE_PREFIX_PATH: ${{ env.DEPENDENCIES_DIR }}
-  # SKELETON_GENERATE_PROJECT_SKIP_END
-  # SKELETON_GENERATE_PROJECT_SKIP_BEGIN
-  cmake-formatting:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Install gersemi
-      run: |
-        pipx install gersemi
-
-    - name: Check formatting
-      run: |
-        ./tools/cmake_formatting.py --diff
   # SKELETON_GENERATE_PROJECT_SKIP_END

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,30 @@
+name: Docker build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Log in to the GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push the CI image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/skeleton/ci:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:24.04
+
+COPY tools/install_dependencies_from_source.cmake /stage/
+
+RUN <<EOF
+#
+####
+set -ex
+#
+#### Install apt packages ####
+apt-get update
+apt-get --yes --quiet install \
+    build-essential \
+    ca-certificates \
+    doxygen \
+    git \
+    ninja-build \
+    pipx \
+    wget
+
+apt-get autoremove
+#
+#### Install Gersemi ####
+pipx install gersemi==0.27.7
+#
+#### Install CMake ####
+wget -P /stage/ https://github.com/Kitware/CMake/releases/download/v4.2.3/cmake-4.2.3-linux-x86_64.sh
+chmod +x /stage/cmake-4.2.3-linux-x86_64.sh
+/stage/cmake-4.2.3-linux-x86_64.sh --prefix=/usr/local --skip-license
+#
+#### Install dependencies ####
+cmake \
+    -D INSTALL_DIR=/dependencies \
+    -P /stage/install_dependencies_from_source.cmake
+#
+#### Cleanup ####
+rm -rf /stage
+rm -rf /dependencies/stage
+ldconfig
+#
+####
+EOF
+
+ENV CMAKE_GENERATOR=Ninja
+ENV CMAKE_PREFIX_PATH=/dependencies
+
+# Add install location of pipx to PATH.
+ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
Add docker/Dockerfile, a GCC/Ubuntu CI image with a pinned CMake and the dependencies baked in via install_dependencies_from_source.cmake. Add a build-docker-image job that publishes it to the GitHub Container Registry, and run the Linux build-and-test job inside it so dependencies are not rebuilt on every run. Windows and macOS keep building dependencies from source with the cached install directory.