### PR TITLE
Require CMake 4.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,6 +64,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    - name: Install CMake
+      uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v3.4.4
+      with:
+        cmakeVersion: "4.2.3"
+
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@v4
@@ -113,6 +118,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+
+    - name: Install CMake
+      uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v3.4.4
+      with:
+        cmakeVersion: "4.2.3"
 
     - name: Create directories
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 4.2)
 
 project(Skeleton VERSION 0.0.1)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 4.2)
 
 project(SkeletonExamples VERSION 0.0.1)
 


### PR DESCRIPTION
Bump cmake_minimum_required to 4.2 for the project and the standalone examples build. The Linux CI image already ships CMake 4.2; install a matching CMake on the Windows, macOS, and generate-project runners so they satisfy the requirement too.